### PR TITLE
update: module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.keploy.io/jsondiff
+module github.com/keploy/jsonDiff
 
 go 1.22
 


### PR DESCRIPTION
* the module name although aligns with our generic convention but it fails when trying to install 
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/aae0ce50-1205-48a7-872a-ad138b912da2">


when manually replacing in go.mod it works
```
replace go.keploy.io/jsondiff => github.com/keploy/jsonDiff v1.0.0

```

hence updated the same