### PR TITLE
chore: update Go version to 1.24 in workflows and go.mod; fix error variable naming in jsondiff.go

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: '1.24'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         - uses: actions/checkout@v3
         - uses: actions/setup-go@v4
           with:
-            go-version: '1.22'
+            go-version: '1.24'
             cache: false
         - name: Run tests
           run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keploy/jsonDiff
 
-go 1.22
+go 1.24
 
 require (
 	github.com/fatih/color v1.17.0

--- a/jsondiff.go
+++ b/jsondiff.go
@@ -70,10 +70,10 @@ func CompareJSON(expectedJSON []byte, actualJSON []byte, noise map[string][]stri
 
 	if t.Kind() == reflect.Map {
 		// Check if the modified keys exist in the provided maps and add additional context if they do.
-		contextInfo, exists, error := checkKeyInMaps(expectedJSON, actualJSON, modifiedKeys)
+		contextInfo, exists, err := checkKeyInMaps(expectedJSON, actualJSON, modifiedKeys)
 
-		if error != nil {
-			return Diff{}, error
+		if err != nil {
+			return Diff{}, err
 		}
 
 		if exists {
@@ -203,7 +203,9 @@ func extractKey(diffString string) string {
 	// Iterate over each line in the diff string.
 	for _, line := range diffLines {
 		// Remove the leading '-' or '+' and any surrounding spaces
-		line = strings.TrimSpace(line[1:])
+		if len(line) > 1 {
+			line = strings.TrimSpace(line[1:])
+		}
 
 		if colonIndex := strings.Index(line, ":"); colonIndex != -1 {
 			// Extract and clean up the key


### PR DESCRIPTION
This pull request includes several updates related to Go version upgrades, error handling improvements, and minor code enhancements. The most important changes include updating the Go version across multiple files, improving error handling in the `CompareJSON` function, and adding a safety check in the `extractKey` function.

Go version updates:

* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48L28-R28): Updated Go version from 1.22 to 1.24.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L21-R21): Updated Go version from 1.22 to 1.24.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated Go version from 1.22 to 1.24.

Error handling improvements:

* [`jsondiff.go`](diffhunk://#diff-ab5d2ac49314d80a4296040d50fa94c987b46467f4b69661ee9459f8e103f754L73-R76): Changed variable name from `error` to `err` in `CompareJSON` function for better error handling and readability.

Code enhancements:

* [`jsondiff.go`](diffhunk://#diff-ab5d2ac49314d80a4296040d50fa94c987b46467f4b69661ee9459f8e103f754R206-R208): Added a length check before trimming lines in the `extractKey` function to prevent potential errors.…ariable naming in jsondiff.go